### PR TITLE
mysql: Tune variables to our environment

### DIFF
--- a/k8s/mariadb/conf.d/zzz-local.cnf
+++ b/k8s/mariadb/conf.d/zzz-local.cnf
@@ -2,10 +2,12 @@
 
 ; Query cache
 query_cache_type        = 1
-query_cache_size        = 32M
+query_cache_size        = 64M
 
 ; Various buffer adjustments
 join_buffer_size        = 2M
+key_buffer_size         = 32M
+max_connections         = 80
 max_tmp_tables          = 128
 max_heap_table_size     = 32M
 read_buffer_size        = 2M
@@ -16,11 +18,16 @@ tmp_table_size          = 32M
 table_definition_cache  = 4096
 table_open_cache        = 4096
 
+; Performance schema
+performance_schema = 1
+
 ; Slow query logging
 long_query_time               = 1
 log_queries_not_using_indexes = 1
 min_examined_row_limit        = 5000
 slow_query_log                = 1
 
-; InnoDB speedup
+; InnoDB settings
+innodb_buffer_pool_size        = 512M
 innodb_flush_log_at_trx_commit = 2
+innodb_log_file_size           = 128M


### PR DESCRIPTION
Changed:
- InnoDB buffers size from 128M to 512M (we are only using InnoDB tables, that's why)
- InnoDB log file size to 128 (mysql-tuner suggests 25% of buffers size)
- MyISAM buffers from 128MB to 32MB (we don't have any myisam tables, sans system ones)
- Query cache size from 32MB to 64MB (phpMyAdmin is reporting large number of evictions)
- Max connections from 150 to 80 (to reduce max memmory footprint)