### PR TITLE
sys/status-logging: Add `/usr/sbin` to `$PATH` in the script itself

### DIFF
--- a/sys/playbooks/files/log-system-status.sh
+++ b/sys/playbooks/files/log-system-status.sh
@@ -7,6 +7,7 @@
 #set -e   # Must not be set, or else one failed command will prevent further processin
 #
 set -u
+export PATH="$PATH:/usr/sbin"   # For iotop
 
 
 


### PR DESCRIPTION
Alternatively, we may want to add it to the crontab when more crons will require it. We can do that later.